### PR TITLE
Charter => governance: add more details, scope, and CNCF SIG references

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,19 +33,11 @@ to create and deploy apps that meet system security requirements
 3. Common libraries and protocols that enable people to reason about the
 security of the system, such as auditing and explainability features.
 
-## Charter
-The charter of the working group is to reduce risk that cloud native
-applications expose end user data or allow other unintended access.
-Distributed deployments across heterogeneous infrastructure are increasingly
-common for cloud native applications. The working group sees common need
-patterns in cloud-native application architecture to improve the security of
-the systems. Without common ways to programatically ensure consistent policy,
-it is increasingly difficult to evaluate system architecture security at scale.
-We propose that the creation of open source libraries, if needed, that enable
-interoperability across software and providers will enable the adoption of
-common protocols for access control. This will in turn accelerate the adoption
-of cloud-native application development models, as well as streamline operations
-for both cloud and traditional infrastructure.
+# Governance
+
+[SIG-Security charter](governance/charter.md) outlines the scope 
+of our group activities, as part of our [governance process](governance) which 
+details how we work.
 
 ## Members
 

--- a/governance/README.md
+++ b/governance/README.md
@@ -1,10 +1,10 @@
 # Governance
 
-The governance of the SAFE Working Group (WG) is facilited by
-Chairs, Technical Leads, and an active group members (see [roles](roles.md)).
+SIG-Security is a [CNCF Special Interest Group](https://github.com/cncf/toc/tree/master/sigs).
 
-Most of the work of the group is conducted by members outside of WG meetings
-(see [process](process.md)). WG meetings serve as a forum for creating a shared
-understanding of the cloud native security landscape with regular updates by
-WG members on project progress and their own security-related, with on-going
-discovery through guest presentations.
+* [Charter](charter.md) - mission and scope
+* [Roles](roles.md) - the work of the group is facilited by Chairs, Technical Leads, and active group members
+* [Process](process.md) - how projects are proposed and work is tracked
+
+General meetings are posted on the CNCF calendar and serve as a forum for creating a shared understanding of the cloud native security landscape with regular updates by members on project progress and their own security-related, with on-going discovery through guest presentations.
+

--- a/governance/charter.md
+++ b/governance/charter.md
@@ -36,12 +36,14 @@ improve overall security in cloud native systems.
 
 ## Focus
 
-Three keys areas:
-* protection of heterogeneous, distributed and fast changing systems, while
+In addition to the [CNCF security-related projects](cncf-projects.md), there
+are three key focus areas:
+* Protection of heterogeneous, distributed and fast changing systems, while
 providing needed access
-* common understanding and common tooling to help developers meet security
+* Common understanding and common tooling to help developers meet security
 requirements
-* common tooling for audit and reasoning about system properties.
+* Common tooling for audit and reasoning about system properties.
+
 
 ### In scope
 

--- a/governance/charter.md
+++ b/governance/charter.md
@@ -7,7 +7,7 @@ and [Governance](#governance) section describes how our operations are consisten
 applications expose end user data or allow other unintended access.
 
 ## Motivation
-Security has been an area in which open source can flourish and sometimes has done so; however, with cloud native platforms and applications security has received less attention than other areas of the cloud native landscape.
+Security has been an area in which open source can flourish and sometimes has done so; however, with cloud native platforms and applications, security has received less attention than other areas of the cloud native landscape.
 
 This means that there is less visibility about the internals of security projects, and fewer projects being deeply integrated into cloud native tooling. While there are many open source security projects, there are fewer security experts focused on the cloud native ecosystem. This has contributed to a culture where people feel they cannot understand how to securely set up and operate cloud native systems, due to obscurity and uncertainty. Yet the cloud native principles, although they mean change, have encouraged the development of tools that help manage fast changing environments, and which have the promise of both simplifying and improving security.
 
@@ -23,12 +23,12 @@ it is increasingly difficult to evaluate system architecture security at scale.
 
 Three keys areas:
 * protection of heterogeneous, distributed and fast changing systems, while providing access that is needed,
-* a common understanding and common tooling to help developers meet security requirements, and
+* common understanding and common tooling to help developers meet security requirements, and
 * common tooling for audit and reasoning about system properties.
 
 ### In scope
 
-Terminology note: SIG-Security uses the term "end-user" to describe the humans who use cloud native applications, whereas CNCF refers to companies that operate cloud native systems as CNCF End Users. In the context of security, we often need to discuss how a particular control affects the people who use the software deployed by a company or organization.
+Terminology note: SIG-Security uses the term "end user" to describe the humans who use cloud native applications, whereas CNCF refers to companies that operate cloud native systems as CNCF End Users. In the context of security, we often need to discuss how a particular control affects the people who use the software deployed by a company or organization.
 
 When we use the word "security" within this group, it is defined to be inclusive of concerns that affect the integrity of the a cloud native
 system or the privacy of its users,  specifically how to enable secure
@@ -60,7 +60,7 @@ the following activities:
 
 Given that the group is comprised of volunteers, specific requests from the TOC
 may be queued according to the bandwidth of the group. The co-chairs will
-facilitate prioritization under the guidance of the SIG-Security CNSF TOC leads.
+facilitate prioritization under the guidance of the SIG-Security CNCF TOC leads.
 
 ### Out of scope
 * Not a standards body: We won't be creating standards.

--- a/governance/charter.md
+++ b/governance/charter.md
@@ -1,15 +1,25 @@
 # SIG-Security Charter (draft)
 
-## Charter
-The charter of the working group is to reduce risk that cloud native
+**Mission:** to reduce risk that cloud native
 applications expose end user data or allow other unintended access.
+
+## Motivation
+Security has been an area in which open source can flourish and sometimes has done so; however, with cloud native platforms and applications security has received less attention than other areas of the cloud native landscape.
+
+This means that there is less visibility about the internals of security projects, and fewer projects being deeply integrated into cloud native tooling. While there are many open source security projects, there are fewer security experts focused on the cloud native ecosystem. This has contributed to a culture where people feel they cannot understand how to securely set up and operate cloud native systems, due to obscurity and uncertainty. Yet the cloud native principles, although they mean change, have encouraged the development of tools that help manage fast changing environments, and which have the promise of both simplifying and improving security.
+
+Making security more open and understandable is an essential part of this change. Talking to customers, security is the most important and least understood part of the cloud native transition. Security is not an easy field, and it is difficult to measure and value the inputs precisely, which can also cause issues with evaluation of security software and designs.
+
 Distributed deployments across heterogeneous infrastructure are increasingly
 common for cloud native applications. The working group sees common need
 patterns in cloud-native application architecture to improve the security of
 the systems. Without common ways to programatically ensure consistent policy,
 it is increasingly difficult to evaluate system architecture security at scale.
-We propose that the creation of open source libraries, if needed, that enable
-interoperability across software and providers will enable the adoption of
-common protocols for access control. This will in turn accelerate the adoption
-of cloud-native application development models, as well as streamline operations
-for both cloud and traditional infrastructure.
+
+## Focus
+
+Three keys areas:
+* protection of heterogeneous, distributed and fast changing systems, while providing access that is needed,
+* a common understanding and common tooling to help developers meet security requirements, and
+* common tooling for audit and reasoning about system properties.
+

--- a/governance/charter.md
+++ b/governance/charter.md
@@ -7,11 +7,25 @@ and [Governance](#governance) section describes how our operations are consisten
 applications expose end user data or allow other unintended access.
 
 ## Motivation
-Security has been an area in which open source can flourish and sometimes has done so; however, with cloud native platforms and applications, security has received less attention than other areas of the cloud native landscape.
+Security has been an area in which open source can flourish and sometimes
+has done so; however, with cloud native platforms and applications, security
+has received less attention than other areas of the cloud native landscape.
 
-This means that there is less visibility about the internals of security projects, and fewer projects being deeply integrated into cloud native tooling. While there are many open source security projects, there are fewer security experts focused on the cloud native ecosystem. This has contributed to a culture where people feel they cannot understand how to securely set up and operate cloud native systems, due to obscurity and uncertainty. Yet the cloud native principles, although they mean change, have encouraged the development of tools that help manage fast changing environments, and which have the promise of both simplifying and improving security.
+This means that there is less visibility about the internals of security
+projects, and fewer projects being deeply integrated into cloud native tooling.
+While there are many open source security projects, there are fewer security
+experts focused on the cloud native ecosystem. This has contributed to a culture
+where people feel they cannot understand how to securely set up and operate
+cloud native systems, due to obscurity and uncertainty. Cloud native principles
+have encouraged the development of tools that help manage fast changing
+environments, and which have the promise of both simplifying and improving
+security.
 
-Making security more open and understandable is an essential part of this change. Talking to customers, security is the most important and least understood part of the cloud native transition. Security is not an easy field, and it is difficult to measure and value the inputs precisely, which can also cause issues with evaluation of security software and designs.
+Making security more open and understandable is an essential part of this
+change. Talking to customers, security is the most important and least
+understood part of the cloud native transition. Security is not an easy field,
+and it is difficult to measure and value the inputs precisely, which can also
+cause issues with evaluation of security software and designs.
 
 Distributed deployments across heterogeneous infrastructure are increasingly
 common for cloud native applications. The working group sees common need
@@ -22,15 +36,22 @@ it is increasingly difficult to evaluate system architecture security at scale.
 ## Focus
 
 Three keys areas:
-* protection of heterogeneous, distributed and fast changing systems, while providing access that is needed,
-* common understanding and common tooling to help developers meet security requirements, and
+* protection of heterogeneous, distributed and fast changing systems, while
+providing needed access
+* common understanding and common tooling to help developers meet security
+requirements
 * common tooling for audit and reasoning about system properties.
 
 ### In scope
 
-Terminology note: SIG-Security uses the term "end user" to describe the humans who use cloud native applications, whereas CNCF refers to companies that operate cloud native systems as CNCF End Users. In the context of security, we often need to discuss how a particular control affects the people who use the software deployed by a company or organization.
+Terminology note: SIG-Security uses the term "end user" to describe the humans
+who use cloud native applications, whereas CNCF refers to companies that operate
+cloud native systems as CNCF End Users. In the context of security, we often
+need to discuss how a particular control affects the people who use the software
+deployed by a company or organization.
 
-When we use the word "security" within this group, it is defined to be inclusive of concerns that affect the integrity of the a cloud native
+When we use the word "security" within this group, it is defined to be inclusive
+of concerns that affect the integrity of the a cloud native
 system or the privacy of its users,  specifically how to enable secure
 access, policy control and safety for operators, administrators,
 developers, and end-users  across the cloud native ecosystem.
@@ -64,15 +85,20 @@ facilitate prioritization under the guidance of the SIG-Security CNCF TOC leads.
 
 ### Out of scope
 * Not a standards body: We won't be creating standards.
-* Not an umbrella organization: We interact with other groups for knowledge sharing, not decision-making.
+* Not an umbrella organization: We interact with other groups for knowledge
+  sharing, not decision-making.
 * Not a compliance body
 * Not a certification board for security of individual projects
 * We will not
-  * answer any specific questions regarding the state of security of any project or product
+  * answer any specific questions regarding the state of security of any project
+    or product
   * consider device security unless there is some impact to cloud systems.
-  * explore trust and safety concerns that are not specific to cloud (e.g. fraud detection, user generated content moderation, spam filtering, phishing, cross-site scripting attacks, SQL injection, etc.)
+  * explore trust and safety concerns that are not specific to cloud
+    (e.g. fraud detection, user generated content moderation, spam filtering,
+    phishing, cross-site scripting attacks, SQL injection, etc.)
 * We will not ensure the saftey of any operational system.
-* This is not related to vulnerability detection and handling any specific security vulnerability or attack.
+* This is not related to vulnerability detection and handling any specific
+  security vulnerability or attack.
 
 ## Governance
 
@@ -81,7 +107,8 @@ ecosystem, so the group seeks to encourage participation and membership across
 a wide range of roles, from diverse companies and organizations.
 
 ### Cross-group relationships
-To focus our efforts, we avoid duplication by developing relationships with other groups that
+To focus our efforts, we avoid duplication by developing relationships with
+other groups that
 focus on a particular technology (such as Kubernetes SIGs) or have a broader
 mandate (such as government organizations).
 
@@ -98,5 +125,6 @@ provided by the CNCF Technical Oversight Committee
 [TOC](https://github.com/cncf/toc).  We have provided a more detailed
 description of roles and process to facilitate group collaboration:
 
-* [Roles](roles.md) - the work of the group is facilited by Chairs, Technical Leads, and active group members
+* [Roles](roles.md) - the work of the group is facilitated by Chairs,
+  Technical Leads, and active group members
 * [Process](process.md) - how projects are proposed and work is tracked

--- a/governance/charter.md
+++ b/governance/charter.md
@@ -40,10 +40,19 @@ tasks from the CNCF TOC that are consistent with the mission, including
 the following activities:
 
 * Publish educational resources on cloud native security
-  * a common vocabulary to talk about and understand cloud native security
-  * block architecture(s) for secure access
-  * CNCF project ecosystem & landscape
   * Videos and/or slides from invited presentations by security providers and use cases
+  * Answer the following questions (referring to already existing resources where possible):
+      * What is different about cloud security? (including hybrid and multi-cloud)
+      * What are effective practices for implementing policy controls?
+      * How can we test, validate, explain, audit our systems?
+      * What additional measures are needed, specific to cloud, in highly regulated environments?
+  * Personas and use cases
+  * Common vocabulary to talk about and understand cloud native security
+  * CNCF project ecosystem & landscape
+  * Define security scenarios (e.g. network configuration, application security, service orchestration)
+  * Block architecture(s) for secure access
+  * Highlight trade-offs (e.g. Expressability vs Explainability)
+  * Best practices and anti-patterns (potentially highlighing where there is disagreement on these)
 * Security assessments of specific proposals or projects
 * Identify projects for consideration for CNCF
 * Cross-pollinate knowledge by participating and inviting people from other projects and SIGs to share security practices
@@ -54,7 +63,16 @@ may be queued according to the bandwidth of the group. The co-chairs will
 facilitate prioritization under the guidance of the SIG-Security CNSF TOC leads.
 
 ### Out of scope
-
+* Not a standards body: We won't be creating standards.
+* Not an umbrella organization: We interact with other groups for knowledge sharing, not decision-making.
+* Not a compliance body
+* Not a certification board for security of individual projects
+* We will not
+  * answer any specific questions regarding the state of security of any project or product
+  * consider device security unless there is some impact to cloud systems.
+  * explore trust and safety concerns that are not specific to cloud (e.g. fraud detection, user generated content moderation, spam filtering, phishing, cross-site scripting attacks, SQL injection, etc.)
+* We will not ensure the saftey of any operational system.
+* This is not related to vulnerability detection and handling any specific security vulnerability or attack.
 
 ## Governance
 

--- a/governance/charter.md
+++ b/governance/charter.md
@@ -82,7 +82,7 @@ the following activities:
 
 Given that the group is comprised of volunteers, specific requests from the TOC
 may be queued according to the bandwidth of the group. The co-chairs will
-facilitate prioritization under the guidance of the SIG-Security CNCF TOC leads.
+facilitate prioritization under the guidance of the SIG-Security TOC liaison.
 
 ### Out of scope
 * Not a standards body: We won't be creating standards.

--- a/governance/charter.md
+++ b/governance/charter.md
@@ -1,4 +1,4 @@
-# SIG-Security Charter (draft)
+# SIG-Security Charter
 
 This charter describes operations as a [CNCF SIG](https://github.com/cncf/toc/blob/master/sigs/). The [Focus](#focus) section below describes what is in and out of scope,
 and [Governance](#governance) section describes how our operations are consistent with CNCF policies with links to more detailed documents.

--- a/governance/charter.md
+++ b/governance/charter.md
@@ -1,0 +1,15 @@
+# SIG-Security Charter (draft)
+
+## Charter
+The charter of the working group is to reduce risk that cloud native
+applications expose end user data or allow other unintended access.
+Distributed deployments across heterogeneous infrastructure are increasingly
+common for cloud native applications. The working group sees common need
+patterns in cloud-native application architecture to improve the security of
+the systems. Without common ways to programatically ensure consistent policy,
+it is increasingly difficult to evaluate system architecture security at scale.
+We propose that the creation of open source libraries, if needed, that enable
+interoperability across software and providers will enable the adoption of
+common protocols for access control. This will in turn accelerate the adoption
+of cloud-native application development models, as well as streamline operations
+for both cloud and traditional infrastructure.

--- a/governance/charter.md
+++ b/governance/charter.md
@@ -1,5 +1,8 @@
 # SIG-Security Charter (draft)
 
+This charter describes operations as a [CNCF SIG](https://github.com/cncf/toc/blob/master/sigs/). The [Focus](#focus) section below describes what is in and out of scope,
+and [Governance](#governance) section describes how our operations are consistent with CNCF policies with links to more detailed documents.
+
 **Mission:** to reduce risk that cloud native
 applications expose end user data or allow other unintended access.
 
@@ -23,3 +26,59 @@ Three keys areas:
 * a common understanding and common tooling to help developers meet security requirements, and
 * common tooling for audit and reasoning about system properties.
 
+### In scope
+
+Terminology note: SIG-Security uses the term "end-user" to describe the humans who use cloud native applications, whereas CNCF refers to companies that operate cloud native systems as CNCF End Users. In the context of security, we often need to discuss how a particular control affects the people who use the software deployed by a company or organization.
+
+When we use the word "security" within this group, it is defined to be inclusive of concerns that affect the integrity of the a cloud native
+system or the privacy of its users,  specifically how to enable secure
+access, policy control and safety for operators, administrators,
+developers, and end-users  across the cloud native ecosystem.
+
+SIG-Security will consider [proposals](proccess.md) from its members or delegated
+tasks from the CNCF TOC that are consistent with the mission, including
+the following activities:
+
+* Publish educational resources on cloud native security
+  * a common vocabulary to talk about and understand cloud native security
+  * block architecture(s) for secure access
+  * CNCF project ecosystem & landscape
+  * Videos and/or slides from invited presentations by security providers and use cases
+* Security assessments of specific proposals or projects
+* Identify projects for consideration for CNCF
+* Cross-pollinate knowledge by participating and inviting people from other projects and SIGs to share security practices
+* Integrate relevant external standards, such as from CII or NIST, as part of educational resoruces and/or SIG processes
+
+Given that the group is comprised of volunteers, specific requests from the TOC
+may be queued according to the bandwidth of the group. The co-chairs will
+facilitate prioritization under the guidance of the SIG-Security CNSF TOC leads.
+
+### Out of scope
+
+
+## Governance
+
+Security must be addressed at all levels of the stack and across the whole
+ecosystem, so the group seeks to encourage participation and membership across
+a wide range of roles, from diverse companies and organizations.
+
+### Cross-group relationships
+To focus our efforts, we avoid duplication by developing relationships with other groups that
+focus on a particular technology (such as Kubernetes SIGs) or have a broader
+mandate (such as government organizations).
+
+As a guide to visitors, we maintain the list of groups in the repo
+[README](https://github.com/cncf/sig-security#related-groups).
+
+Co-chairs are responsible to ensure periodic cross-group knowledge sharing,
+which is accomplished by cross-group membership, invitation to present at
+a SIG meeting and/or offering to present to the related group.
+
+## Operations
+SIG-Security operations are consistent with standard SIG operating guidelines
+provided by the CNCF Technical Oversight Committee
+[TOC](https://github.com/cncf/toc).  We have provided a more detailed
+description of roles and process to facilitate group collaboration:
+
+* [Roles](roles.md) - the work of the group is facilited by Chairs, Technical Leads, and active group members
+* [Process](process.md) - how projects are proposed and work is tracked

--- a/governance/charter.md
+++ b/governance/charter.md
@@ -4,7 +4,7 @@ This charter describes operations as a [CNCF SIG](https://github.com/cncf/toc/bl
 and [Governance](#governance) section describes how our operations are consistent with CNCF policies with links to more detailed documents.
 
 **Mission:** to reduce risk that cloud native
-applications expose end user data or allow other unintended access.
+applications expose end user data or allow other unauthorized access.
 
 ## Motivation
 Security has been an area in which open source can flourish and sometimes
@@ -28,10 +28,11 @@ and it is difficult to measure and value the inputs precisely, which can also
 cause issues with evaluation of security software and designs.
 
 Distributed deployments across heterogeneous infrastructure are increasingly
-common for cloud native applications. The working group sees common need
-patterns in cloud-native application architecture to improve the security of
-the systems. Without common ways to programatically ensure consistent policy,
+common for cloud native applications.
+Without common ways to programatically ensure consistent policy,
 it is increasingly difficult to evaluate system architecture security at scale.
+Emerging common architectural patterns offer the opportunity
+improve overall security in cloud native systems.
 
 ## Focus
 
@@ -122,9 +123,6 @@ a SIG meeting and/or offering to present to the related group.
 ## Operations
 SIG-Security operations are consistent with standard SIG operating guidelines
 provided by the CNCF Technical Oversight Committee
-[TOC](https://github.com/cncf/toc).  We have provided a more detailed
-description of roles and process to facilitate group collaboration:
+[TOC](https://github.com/cncf/toc). 
 
-* [Roles](roles.md) - the work of the group is facilitated by Chairs,
-  Technical Leads, and active group members
-* [Process](process.md) - how projects are proposed and work is tracked
+Full details of process and roles are linked from [governance README](/governance).

--- a/governance/charter.md
+++ b/governance/charter.md
@@ -97,7 +97,7 @@ facilitate prioritization under the guidance of the SIG-Security CNCF TOC leads.
   * explore trust and safety concerns that are not specific to cloud
     (e.g. fraud detection, user generated content moderation, spam filtering,
     phishing, cross-site scripting attacks, SQL injection, etc.)
-* We will not ensure the saftey of any operational system.
+* We will not ensure the safety of any operational system.
 * This is not related to vulnerability detection and handling any specific
   security vulnerability or attack.
 

--- a/governance/charter.md
+++ b/governance/charter.md
@@ -73,12 +73,12 @@ the following activities:
   * CNCF project ecosystem & landscape
   * Define security scenarios (e.g. network configuration, application security, service orchestration)
   * Block architecture(s) for secure access
-  * Highlight trade-offs (e.g. Expressability vs Explainability)
-  * Best practices and anti-patterns (potentially highlighing where there is disagreement on these)
+  * Highlight trade-offs (e.g. Expressibility vs Explainability)
+  * Best practices and anti-patterns (potentially highlighting where there is disagreement on these)
 * Security assessments of specific proposals or projects
 * Identify projects for consideration for CNCF
 * Cross-pollinate knowledge by participating and inviting people from other projects and SIGs to share security practices
-* Integrate relevant external standards, such as from CII or NIST, as part of educational resoruces and/or SIG processes
+* Integrate relevant external standards, such as from CII or NIST, as part of educational resources and/or SIG processes
 
 Given that the group is comprised of volunteers, specific requests from the TOC
 may be queued according to the bandwidth of the group. The co-chairs will
@@ -113,7 +113,7 @@ other groups that
 focus on a particular technology (such as Kubernetes SIGs) or have a broader
 mandate (such as government organizations).
 
-As a guide to visitors, we maintain the list of groups in the repo
+As a guide to visitors, we maintain the list of groups in the SIG
 [README](https://github.com/cncf/sig-security#related-groups).
 
 Co-chairs are responsible to ensure periodic cross-group knowledge sharing,
@@ -123,6 +123,6 @@ a SIG meeting and/or offering to present to the related group.
 ## Operations
 SIG-Security operations are consistent with standard SIG operating guidelines
 provided by the CNCF Technical Oversight Committee
-[TOC](https://github.com/cncf/toc). 
+[TOC](https://github.com/cncf/toc).
 
 Full details of process and roles are linked from [governance README](/governance).

--- a/governance/cncf-projects.md
+++ b/governance/cncf-projects.md
@@ -1,0 +1,17 @@
+## CNCF Projects
+
+The CNCF TOC identifies specific project that provide capabilities related
+to security, including policy, identity, authentication, authorization,
+auditing, compliance, cost management, etc.
+
+These are known as "Security Providers" and the SIG will prioritize review of
+each project's annual [security assessment](/assessments).
+
+Current list of projects:
+
+* Falco
+* Open Policy Agent
+* Notary
+* TUF
+* SPIFFE
+* SPIRE

--- a/governance/process.md
+++ b/governance/process.md
@@ -2,14 +2,14 @@
 
 Each proposal is unique and might deviate slightly from the process below. For
 example, a small addition may not require completion criteria. In general, we
-encourage this process below to be followed to ensure that contributions are in
-line with the goals of the Working Group.
+encourage the process below to be followed to ensure that contributions are in
+line with the [mission and charter](charter.md).
 
 ### Proposal process
 
 1. **Raise an Issue:**
-[Create an issue](https://github.com/cncf/sig-security/issues/new) in the SAFE
-repo that outlines the problem to be solved. If possible, include:
+[Create an issue](https://github.com/cncf/sig-security/issues/new)
+that outlines the problem to be solved. If possible, include:
     * The customer impact of the problem
     * The scope of the work required
 
@@ -17,7 +17,7 @@ repo that outlines the problem to be solved. If possible, include:
 on a solution, bring the issue up for discussion at a meeting, explain it, and
 ask if others are interested in collaborating. This ensures that solutions are
 created with multiple perspectives. The outcome of this conversation will be:
-    * The group agrees that this is a problem within the scope if the Working
+    * The group agrees that this problem is appropriate scope
   Group.
     * Criteria for completion are added to the issue that include a "definition
   of done", ideally with validation by the target audience. Also note in the
@@ -25,15 +25,33 @@ created with multiple perspectives. The outcome of this conversation will be:
     * At least one person is tasked with creating a solution
     * Those interested in working on the solution either begin work or set up
   time or expectations with others to begin work.
-    * A Technical Lead agrees to actively sponsor the work.
+    * A Chair or Technical Lead agrees to act as Representative, which means
+    they will take responsibility to ensure that progress is tracked and
+    that outcomes are reported to the group or propose closing the
+    issue if there is not sufficent activity to sustain the effort.
+
+1. **Accept or close the proposal.** Accepted proposals will be assigned
+to the Representative and the active members working on the project should
+be noted in the issue, along with information about expected duration and
+milestones. If a proposal is closed, it should note the reason and link to
+discussion minutes.
+
+
+### Active projects
 
 1. **Track progress.** As long as work is ongoing, progress should be tracked
-both in the Issue or PR and in meetings.
+both in the Issue and reported on periodically in meetings.
     * Someone working on the project will attend weekly meetings to answer
-  questions. In case of their absence, ensure that the Technical Lead or their
-  delegate is informed about the latest changes in case questions arise.
-    * It's strongly encouraged to include a checklist that shows what has been
-  done and what work remains in the Issue or PR.
+  questions. In case of absence, ensure that github issues is updated and
+  another member of the group who can attend the meeting is familiar with
+  progress in case questions arise.
+    * It's strongly encouraged to include a checklist in the Isssue
+  that shows what has been done and what work remains.
+
+1. **Pull Requests.** Completed work should result in a Pull Request (PR).
+At minimum, an update to one of the group documents or roadmap indicating that
+the work was done. Typically projects will result in an artifact that will
+contribute to the information in this repository.
 
 1. **Discuss the work at a meeting.** If an objection to a PR is made either in
 a comment of the PR or during a meeting, the person making the objection and
@@ -49,13 +67,12 @@ a formal vote is required. A comment will be left on the proposal prompting
 members to vote and indicating the time the vote will close. Only one member
 from each company should vote. Members will vote by leaving a comment in the
 Pull Request to indicate their vote for or against. Members will have a week
-after the vote begins to leave their vote.
+after the vote begins to leave their vote. Quorum is taken to be 2/3 the number
+of companies who have been active in the past month (via issue comment or 
+meeting attendace as recorded in the public minutes).
 
-1. **Accept or close the proposal.** Depending on the outcome of a discussion,
-a Chair will merge or close the proposal. If a proposal is closed, the group
-should create a plan to address the underlying user problem that the proposal
-intended to address.
 
 1. **Support the project going forward.** Some projects require ongoing
 support. When work is completed, the body of the Pull Request should specify if
-it's expected to require on-going support and if so, who will maintain it.
+it's expected to require on-going support and if so, who will maintain it.ccept
+

--- a/governance/roles.md
+++ b/governance/roles.md
@@ -1,17 +1,20 @@
-
 ## Working Group Roles
 
 * [Three Chairs](#role-of-chairs)
-* [Technical Leads](#role-of-technical-leads) for each substantive block of work
-* Group [Members](#role-of-members)
+* [Technical Leads](#role-of-technical-leads)
+* [Project Leads](#role-of-project-leads)
+* [Group Members](#role-of-members)
+* [TOC Liaison](#toc-liaison)
 
 The group may have many members. Within this document, "member" may refer to a Chair, a Technical Lead, or a Member.
 
+All Members are identified in the SIG [README](/readme.md), with annotations
+where they hold an additional role.
+
 ### Role of Members
 * The primary role of a member is to contribute expertise to the group.
-* Initial members are defined at the founding of the Working Group (WG).
-* To add yourself as a member, submit a PR adding yourself to the list of
-members.
+* To add yourself as a member, submit a Pull Request (PR) adding yourself
+to the list of members.
 * Members *SHOULD* remain active and responsive in their Roles.
 * Members taking an extended leave of 1 or more months *SHOULD* coordinate with
 other members to ensure the role is adequately staffed during the leave.
@@ -22,48 +25,68 @@ communicated a leave of absence and either cannot be reached for more than 1
 month or are not fulfilling their documented responsibilities for more than 1
 month. This may be done through a super-majority vote of members, or if there
 are not enough *active* members to get a super-majority of votes cast, then
-removal may occur through a super-majority vote between Chairs and Technical
-Leads. Those roles are described below.
-* Membership disagreements may be escalated to the WG Chairs.  Disagreements
-among the WG Chairs may be escalated to the CNCF Steering Committee.
+removal may occur through a super-majority vote of the Chairs.
+* Membership disagreements may be escalated to the Chairs.  Disagreements
+among the Chairs may be escalated to the TOC Liaison.
 * Members *MAY* decide to step down at anytime and optionally propose a
 replacement.
-* The group will use lazy consensus amongst other members with fallback on
-majority vote to accept proposal.  The proposal *SHOULD* be supported by a
-majority of WG Members.
+* Members contribute to projects, according to the standard group [process](process.md).
 
 ### Role of Chairs
 
-* Primary role of Chairs is to run operations and the governance of the WG.
-* The Chairs are responsible for providing technical guidance, for bringing up
-proposals that have been submitted, and for asking for new proposals to be made.
-* A chair will serve in their role for 2 years from the time they started in
-the role, and *MAY* run again indefinitely.
-* To fill a vacancy for a new chair, the group will announce with at least two
-week’s notice that a vote for chair will occur. Each company will have one
-vote. Any group member is eligible to run for Chair.
-* There will be three chairs and their membership will be tracked in
-[`wg.yaml`]().
+While CNCF TOC allows for Chairs to serve in purely administrative roles,
+SIG-Security was formed with deeply technical Chairs based on early need
+to navigate a complex security landscape. Until at least two Technical Leads
+are identified, any Chair may act as Technical Lead.
 
+* Primary role of Chairs is to run operations and the governance of the group.
+* The Chairs are responsible for
+  * setting the agenda for meetings
+  * extending discussion via asynchronous communication to be inclusive of
+members who cannot attend a specific meeting time.
+  * scheduling discussing of proposals that have been submitted
+  * asking for new proposals to be made to address an identified need
 
 ### Role of Technical Leads
 
-Technical Leads (TLs) will lead larger streams of work that require sustained
-technical leadership. Any new proposal should have a TL working as an active
-sponsor of the proposal, guiding the proposal with the engagement of community.
+Technical Leads (TLs) expand the bandwidth of the leadership team. Proposals
+must have a TL or Chair working as an active sponsor
+(as detailed in [SIG process](process.md)).
+
 The general list of activities for TL are:
   * Establish new subprojects
   * Decommission existing subprojects
   * Resolve cross-subproject technical issues and decisions
+  * Propose agenda items for meetings to ensure that open issues are
+  discussed with the group when needed
 
-There will be two to three TLs and their membership will be tracked in
-[`wg.yaml`](). TLs are elected by the following process:
-  1. one of the Chairs nominates a candidate to be a TL, and creates a PR that
-  adds the TL to [`wg.yaml`]().
+TLs are elected by the following process:
+  1. One of the Chairs nominates a candidate to be a TL, and creates a PR that
+  adds the TL to the [SIG README](/README.md).
   1. Members are invited to comment and vote according to the regular voting
   process described below.
 
-Technical Leads will serve in their role as long as they are necessary. They
-can resign at any time. If it's necessary to remove to TL, that will be done by
-the WG Chairs. All changes should be reflected in `wg.yaml`.
+### Role of Project Leads
 
+Project Leads will lead larger streams of work that require sustained
+effort and coordination.
+
+Project Leads are nominated and approved by the following process:
+  1. Project Lead actively participates in the group, making a proposal or
+  volunteering to take on a project that has been prioritized by the group
+  1. A Chair or TL nominates a candidate.
+  1. The nomination is communicated via a pull request annotating the list of members in the [SIG README](/README.md) with a link to the issue tracking the project. The nomination is typically open for a week (but may be shorter with
+  LGTM of at least two chairs).
+  1. Members are encouraged to review the tracking issue and work together
+  to ensure that the Project Lead is set up for success or suggest alternatives.
+
+
+## TOC Liaison
+
+The [CNCF SIG](https://github.com/cncf/toc/blob/master/sigs) process identifies
+a TOC Liaison.  The SIG chairs are responsible for establishing effective
+communication with the TOC liaison, including further communication to the
+wider TOC upon request.
+
+The TOC Liaison will occasionally prioritize SIG activities, as needed by the
+TOC, to further the [CNCF mission](https://github.com/cncf/foundation/blob/master/charter.md#1-mission-of-the-cloud-native-computing-foundation).

--- a/usecases.md
+++ b/usecases.md
@@ -2,12 +2,12 @@ Authors: stummidi@pivotal.io, rayc@google.com, pragashjj@gmail.com, ckemper@goog
 
 Updated: 9 April 2019
 
-This is a living document, please feel free to add use cases and personas through a PR. 
-This initial version was derived from inputs referencd below.  Please add 
-references for new use cases, which could included shared documents from other 
+This is a living document, please feel free to add use cases and personas through a PR.
+This initial version was derived from inputs referencd below.  Please add
+references for new use cases, which could included shared documents from other
 projects, published research or case studies of cloud native technologies in
 real world use.
- 
+
 ## References
 
 * SAFE Cloud Foundry Use Cases: https://goo.gl/4pmdqt
@@ -20,24 +20,24 @@ for users of cloud native technology.
 
 ## Users
 
-Within an enterprise, based on the organization structure, we may have one or 
+Within an enterprise, based on the organization structure, we may have one or
 more of the personas. The more general user categories are
-separated into these more detailed personas where roles may be held by 
+separated into these more detailed personas where roles may be held by
 different people in a large organization.
 
 * Operators: Enterprise, Quota, Network
 * Administrators: Security, Compliance/Audit
 * Developers, including Third Party Security Products
-* End-users 
+* End-users
 
 A project will often have a very focused target audience and not all
 use cases are applicable in every situaton.  The use cases below are a guide
 to consider common needs that often require support from multiple products
 or technologies in order to be fully functional for the target users.
 
-# Operators
+# Operator
 
-## Enterprise 
+## Enterprise
 
 * As an enterprise operator, I need a central way to look at the organizational resources, so that I can administer them in a single view
 
@@ -56,7 +56,7 @@ or technologies in order to be fully functional for the target users.
 * As an enterprise operator, I can understand the effect of changes to policy that I am making
 
 
-## Quota 
+## Quota
 
 Since quota is often used for cost control, this may imply a different persona
 with financial, rather than an engineering background.
@@ -85,7 +85,7 @@ impact of repeated request on the rest of the infrastructure.
 * As a quota operator, I can understand the effect of changes to quota that I am making
 
 
-## Network 
+## Network
 
 * As a network operator, I need a central way to look at the networks in my organization, so that I can administer them in a single view.
 
@@ -98,7 +98,7 @@ impact of repeated request on the rest of the infrastructure.
 * As a network operator, I can understand the effect of changes to network policy that I am making
 
 
-# Administrators
+# Administrator
 
 ## Compliance Officer / Auditor
 
@@ -133,7 +133,7 @@ impact of repeated request on the rest of the infrastructure.
 
 * As a security administrator, I can <a href="https://docs.google.com/document/d/19V_Vx0fdz2HOa31FpPswT9CsUphizfJcwvDJv05aWFs/edit#heading=h.7wavwjkp2pz2" target="_blank">exercise the above rights in hybrid and mutli-cloud deployments</a>  without compromising my ability to manage my organizations’ cloud resources.
 
-# Developers
+# Developer
 
 * As a developer, I need to provide logs for any changes to a critical resources, such that they can be made available for auditing
 
@@ -150,7 +150,7 @@ impact of repeated request on the rest of the infrastructure.
 
 
 
-# End-users
+# End user
 
 * As an end user, I can understand which resources I can access and how I can request access to a resource
 


### PR DESCRIPTION
The CNCF TOC SIG process include approval of the [charter](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#sig-charter).
To facilitate that, this PR is refactors original charter from README 
into the governance folders. 

Then added:
* some from the [Worked Example](https://docs.google.com/document/d/18ufx6TjPavfZubwrpyMwz6KkU-YA_aHaHmBBQkplnr0/edit) which SAFE WG members drafted in collaboration with TOC members
* included scope from #23 
* Consistency for "end user" -- remove the dash, since it's a noun here (see below) -- prior version was inconsistent even within a single doc (usecases.md). The [CNCF Style Guide](https://github.com/cncf/foundation/blob/master/style-guide.md) doesn't have specific guidance but they use "end user" and for other things refer to [IEEE Style Guide](https://ieeecs-media.computer.org/assets/pdf/2016CSStyleGuide.pdf):
    > end user (n.), end-user (adj.): the ultimate user or customer. Use just “user” unless
distinguishing different types of users, such as a testing user or support user. Consider
substituting “customer.”
* updated roles to be consistent with new CNCF roles, factoring out new "Project Lead" role since technical leads now require 2/3 majority vote of CNCF TOC
* added list of CNCF projects from the list in the CNCF TOC SIG process doc (per request of @caniszczyk)

