### PR TITLE
contribution guide and code-of-conduct

### DIFF
--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -1,0 +1,36 @@
+# Code of Conduct 
+
+We follow the 
+[CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md) 
+
+As part of our pledge to respect all people, in both live in-person and online
+interactions, we are committed to providing a friendly, safe and welcoming
+environment for all, regardless of gender, gender identity and expression,
+sexual orientation, disability, physical appearance, body size, race, religion,
+native language, operating system choice, current software stack or prior
+experience. 
+
+In keeping with this commitment, we offer the following guidelines:
+   * Welcome newcomers at any stage of expertise. 
+     * Everyone has something to contribute. 
+     * Everyone deserves access to materials and community that will help them learn. 
+     * As long as an individual can be respectful and not disruptive to other participants, they deserve to participate.
+   * Provide open and free material.
+   * Be kind and courteous.
+     * Interpret the arguments of others in good faith, offering private
+     constructive feedback when communication style bears improvement.
+     * Leave space for quieter voices.
+   * Consider who is not in the room. 
+     * Invite participation from experts or user community representatives
+     outside of the working group.
+     * Participate in online forums to be inclusive of those who cannot 
+     attend meetings.
+
+
+# Inspiration
+
+The above guidelines are inspired by and borrowed from other communities:
+
+* https://bridgefoundry.org/code-of-conduct
+* https://www.rust-lang.org/policies/code-of-conduct
+* https://golang.org/conduct

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+## Contributing
+
+We aspire to create a welcoming environment for collaboration on this project
+and ask that all contributors do the same. For more details, see our
+[code of conduct](CODE-OF-CONDUCT.md).
+
+This document covers contributions to this git repository. Please review
+[governance](governance) for our mission, charter, and other operations.
+
+### Open source
+
+While this repository does not contain open source code, we manage content
+contributions following open source practice, as detailed below.
+
+All contributions to this project will be released under the 
+[Apache License](LICENSE) By submitting a pull request (PR), you are agreeing to
+release the PR contents under this license.
+
+## Communication
+
+Anyone interested in contributing should join the mailing list and other
+[communication channels](README.md#Communications)
+
+### Reviewing Pull Requests
+
+If you are new to the group, reviewing pull requests and commenting on issues
+is a great way to get involved!
+
+Except for urgent or very small grammar or spelling fixes, we leave pull 
+requests open for at least 24 hours, so that others have the chance to 
+review/comment.   
+
+Anyone who reviews a pull request should leave a note to let others know that 
+someone has looked at it.  Any change should have a +1 from someone else.
+Larger changes should have multiple reviewers.
+
+### Writing style
+
+Consistency creates clarity in communication. 
+
+* When referring to users and use cases, ensure consistency with [/usecases.md] 
+* See [CNCF Style
+  Guide](https://github.com/cncf/foundation/blob/master/style-guide.md) for
+  common terms. Note that the following terms are not hyphenated and all lower
+  case, except for capitalizing the first letter when at the beginning of a
+  sentence:
+  * open source
+  * cloud native
+* Additional capitalization notes
+  * Headlines, page titles, subheads and similar content should follow sentence
+    case, and should not include a trailing colon. 
+
+If you find yourself correcting for consistency, please propose additional style
+guidelines via pull request to this document. Feel free to add references to 
+good sources for content guidelines below.
+
+Sources:
+* [OpenOpps Contribution Guide](https://github.com/openopps/openopps-platform/blob/master/CONTRIBUTING.md)
+* [18F Content Guide](https://content-guide.18f.gov/)
+


### PR DESCRIPTION
first cut at contribution guide: https://github.com/cncf/sig-security/issues/180

added a code-of-conduct since it felt like CNCF version was mostly focused on code and wanted to expand on expectations for live, in-person interactions