### PR TITLE
document currently active roles

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -20,10 +20,6 @@ collaborators:
 
   - username: pragashj
     permission: admin
-
-    # Security Assessment Facilitator
-  - username: JustinCappos
-    permission: push
   
     # Triage Team
   - username: lumjjb
@@ -32,3 +28,11 @@ collaborators:
   - username: hannibalhuang
     permission: push
     
+    # Security Assessment Facilitator
+  - username: JustinCappos
+    permission: push
+
+    # Security Reviewers
+  # JustinCappos, ultrasaurus, lumjjb
+  - username: JustinCormack
+    permission: push

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -13,19 +13,19 @@ repository:
   # Collaborators: give specific users access to this repository.
 collaborators:
   - username: ultrasaurus
-    # Note: Only valid on organization-owned repositories.
-    # The permission to grant the collaborator. Can be one of:
-    # * `pull` - can pull, but not push to or administer this repository.
-    # * `push` - can pull and push, but not administer this repository.
-    # * `admin` - can pull, push and administer this repository.
+    permission: admin
+
+  - username: dshaw
     permission: admin
 
   - username: pragashj
     permission: admin
 
+    # Security Assessment Facilitator
   - username: JustinCappos
     permission: push
   
+    # Triage Team
   - username: lumjjb
     permission: push
 

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,7 +11,12 @@ repository:
   homepage: https://cncf.io/projects
   
   # Collaborators: give specific users access to this repository.
+  # see /governance/roles.md for details on write access policy
+  # note that the permissions below may provide wider access than needed for
+  # a specific role, and we trust these individuals to act according to their
+  # role. If there are questions, please contact one of the chairs.
 collaborators:
+  # Chairs
   - username: ultrasaurus
     permission: admin
 
@@ -22,6 +27,7 @@ collaborators:
     permission: admin
   
     # Triage Team
+    # manage issues (edit labels, occasionally edit)
   - username: lumjjb
     permission: push
 
@@ -29,10 +35,14 @@ collaborators:
     permission: push
     
     # Security Assessment Facilitator
+    # merge PRs in /assesssments according to guidelines
+    # triage related issues
   - username: JustinCappos
     permission: push
 
     # Security Reviewers
-  # JustinCappos, ultrasaurus, lumjjb
+    # issues may be assigned, edited by assignee
+    # merge PRs for assigned issue according to guidelines
+    # JustinCappos, ultrasaurus, lumjjb
   - username: JustinCormack
     permission: push

--- a/assessments/guide/security-reviewer.md
+++ b/assessments/guide/security-reviewer.md
@@ -1,4 +1,4 @@
-# Security Reviewers
+# Security Reviewer Role
 
 Reviewers will try to understand the system and probe its security.
 Specifically design level issues are meant to be addressed as well as high
@@ -22,7 +22,7 @@ encouraged to have participation (shadowing) from participants that are not
 yet qualified to help them gain the necessary skills to be a reviewer
 in the future.
 
-## Time and Effort
+## Time and effort
 
 The level of effort for the reviewers is expected to be 10 hours per review.
 Despite the fact that there may be some back and forth to get clarification
@@ -30,7 +30,7 @@ on a few points, it is expected analysis can usually be concluded in a few
 weeks.  This will primarily involve carefully reading the written
 document and analyzing the security assertions and assumptions.
 
-# Security Reviewer Expectations
+# Expectations
 
 GitHub issues are assigned to Security Reviewers. Security Reviewers are 
 expected to conduct an in-depth review described in the [Security Assessment

--- a/assessments/guide/security-reviewer.md
+++ b/assessments/guide/security-reviewer.md
@@ -1,14 +1,14 @@
 # Security Reviewers
 
-Reviewers will try to understand the
-system and probe its security.  Specifically design level issues are meant
-to be addressed as well as high level problems with the project’s setup and
-operation. This is meant to provide an independent analysis and estimation
-of the above information.  The goal is to ask questions to understand if
-there are hidden assumptions, underestimated risk, or design issues that
-harm the security of the project.  It may be useful to reach out to
-community members to understand the answers to some questions, especially
-involving deployment scenarios and the impact of attacks.
+Reviewers will try to understand the system and probe its security.
+Specifically design level issues are meant to be addressed as well as high
+level problems with the project’s setup and operation. This is meant to 
+provide an independent analysis and estimation of the above information. 
+The goal is to ask questions to understand if there are hidden assumptions,
+underestimated risk, or design issues that harm the security of the project. 
+It may be useful to reach out to community members to understand the answers
+to some questions, especially involving deployment scenarios and the impact
+ of attacks.
 
 ## Qualifications
 
@@ -22,10 +22,18 @@ encouraged to have participation (shadowing) from participants that are not
 yet qualified to help them gain the necessary skills to be a reviewer
 in the future.
 
-## Time and effort
+## Time and Effort
 
-The level of effort for the reviewers is expected to be 10 hours.
+The level of effort for the reviewers is expected to be 10 hours per review.
 Despite the fact that there may be some back and forth to get clarification
 on a few points, it is expected analysis can usually be concluded in a few
 weeks.  This will primarily involve carefully reading the written
 document and analyzing the security assertions and assumptions.
+
+# Security Reviewer Expectations
+
+GitHub issues are assigned to Security Reviewers. Security Reviewers are 
+expected to conduct an in-depth review described in the [Security Assessment
+Guide](./). Security Reviewers should seek the approval of the other 
+participating Security Reviewers and at least 1 co-chair before merging.
+

--- a/assessments/guide/security-reviewer.md
+++ b/assessments/guide/security-reviewer.md
@@ -30,7 +30,7 @@ on a few points, it is expected analysis can usually be concluded in a few
 weeks.  This will primarily involve carefully reading the written
 document and analyzing the security assertions and assumptions.
 
-# Expectations
+## Expectations
 
 GitHub issues are assigned to Security Reviewers. Security Reviewers are 
 expected to conduct an in-depth review described in the [Security Assessment

--- a/governance/roles.md
+++ b/governance/roles.md
@@ -1,17 +1,18 @@
-## Working Group Roles
+## Working group roles
 
 * [Three Chairs](#role-of-chairs)
 * [Technical Leads](#role-of-technical-leads)
 * [Project Leads](#role-of-project-leads)
 * [Group Members](#role-of-members)
 * [TOC Liaison](#toc-liaison)
+* [Facilitation Roles](#facilitation)
 
 The group may have many members. Within this document, "member" may refer to a Chair, a Technical Lead, or a Member.
 
 All Members are identified in the SIG [README](/readme.md), with annotations
 where they hold an additional role.
 
-### Role of Members
+### Role of members
 * The primary role of a member is to contribute expertise to the group.
 * To add yourself as a member, submit a Pull Request (PR) adding yourself
 to the list of members.
@@ -30,9 +31,10 @@ removal may occur through a super-majority vote of the Chairs.
 among the Chairs may be escalated to the TOC Liaison.
 * Members *MAY* decide to step down at anytime and optionally propose a
 replacement.
-* Members contribute to projects, according to the standard group [process](process.md).
+* Members contribute to projects, according to the standard group
+  [process](process.md).
 
-### Role of Chairs
+### Role of chairs
 
 While CNCF TOC allows for Chairs to serve in purely administrative roles,
 SIG-Security was formed with deeply technical Chairs based on early need
@@ -47,7 +49,7 @@ members who cannot attend a specific meeting time.
   * scheduling discussing of proposals that have been submitted
   * asking for new proposals to be made to address an identified need
 
-### Role of Technical Leads
+### Role of technical leads
 
 Technical Leads (TLs) expand the bandwidth of the leadership team. Proposals
 must have a TL or Chair working as an active sponsor
@@ -66,7 +68,7 @@ TLs are elected by the following process:
   1. Members are invited to comment and vote according to the regular voting
   process described below.
 
-### Role of Project Leads
+### Role of project leads
 
 Project Leads will lead larger streams of work that require sustained
 effort and coordination.
@@ -81,7 +83,7 @@ Project Leads are nominated and approved by the following process:
   to ensure that the Project Lead is set up for success or suggest alternatives.
 
 
-## TOC Liaison
+## TOC liaison
 
 The [CNCF SIG](https://github.com/cncf/toc/blob/master/sigs) process identifies
 a TOC Liaison.  The SIG chairs are responsible for establishing effective
@@ -90,3 +92,48 @@ wider TOC upon request.
 
 The TOC Liaison will occasionally prioritize SIG activities, as needed by the
 TOC, to further the [CNCF mission](https://github.com/cncf/foundation/blob/master/charter.md#1-mission-of-the-cloud-native-computing-foundation).
+
+
+## Facilitation roles
+
+Facilitation roles are identified in [github settings](/.github/settings.yaml)
+and include additional permissions in the repo which are governed by policies
+described below.
+
+### Security assessment facilitator
+
+[Security Assessments](/assessments) are part of the on-going work of the group
+and led by a Security assessment facilitator, who will:
+
+* coordinate security review leads for upcoming security assessments.
+* identify and recommend security reviewers.
+* contribute to process improvements.
+* review and merge PRs in the /assessments directory (ensuring co-chair review
+  of significant process changes).
+* triage issues related to security assessments.
+
+
+### Triage Team
+
+All members are expected to review Pull Requests (PRs), comment on issues, and 
+provide meaningful feedback or helpful references.
+
+Members who have contributed regularly, including discussion on multiple
+PRs and submitting PRs themselves, can volunteer to participate as a member
+of the Triage Team.  Interested members should first join ` #sig-security-triage`
+on Slack and flag issues that need attention, ask questions and volunteer
+to take on process improvement PRs that may arise.
+
+When there is a vacancy or need additional help, they will ask on Slack for
+volunteers to officially join the team.
+
+Each member of the Triage Team will:
+
+* assign labels to issues.
+* comment where issues need more detail.
+* recommend proposals or suggestions for discussion at working session meetings.
+* paricipate on #sig-security-triage slack channel.
+
+
+
+

--- a/governance/roles.md
+++ b/governance/roles.md
@@ -100,10 +100,10 @@ Facilitation roles are identified in [github settings](/.github/settings.yaml)
 and include additional permissions in the repo which are governed by policies
 described below.
 
-### Security assessment facilitator
+### Security Assessment Facilitator
 
 [Security Assessments](/assessments) are part of the on-going work of the group
-and led by a Security assessment facilitator, who will:
+and led by a Security Assessment Facilitator, who will:
 
 * coordinate security review leads for upcoming security assessments.
 * identify and recommend security reviewers.
@@ -132,8 +132,12 @@ Each member of the Triage Team will:
 * assign labels to issues.
 * comment where issues need more detail.
 * recommend proposals or suggestions for discussion at working session meetings.
-* paricipate on #sig-security-triage slack channel.
+* participate on #sig-security-triage slack channel.
 
+### Project teams
 
+Some on-going projects may have teams where members are identified for
+additional roles and may be required to have specific expertise. For visibility,
+these additional project roles are listed below:  
 
-
+* [Security Reviewers](../assessments/guide/security-reviewer.md/)


### PR DESCRIPTION
add details for 
- triage team (https://github.com/cncf/sig-security/issues/198)
- security assessment facilitator