### PR TITLE
add Justin Cormack as a meeting facilitator

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -48,4 +48,4 @@ collaborators:
     permission: push
 
     # Meeting Facilitators
-    # ultrasaurus, dshaw, pragashj, lumjjb
+    # ultrasaurus, dshaw, pragashj, lumjjb, justincormack


### PR DESCRIPTION
Signed-off-by: Justin Cormack <justin.cormack@docker.com>