### PR TITLE
Create policy-team-intro.md

### DIFF
--- a/policy/policy-team-intro.md
+++ b/policy/policy-team-intro.md
@@ -1,0 +1,21 @@
+# CNCF Security SIG Policy Team Introduction
+
+## Background
+
+When SAFE WG was originally proposed, developers from Kubernetes Policy WG actively participated the discussions and then proposed CNCF level Policy WG was [merged](../policy-wg-merging.md) with SAFE WG to form the current CNCF Security SIG. Policy is also mentioned as part of the SIG [mission](../README.md).
+
+## Policy Team
+
+The Policy Team in CNCF Security SIG consists of the same set of developers that forms the Kubernetes Policy WG. The only difference is the topic coverage (whether it is at Kubernetes level or CNCF level).
+
+The Policy Team runs [bi-weekly meeting](https://docs.google.com/document/d/1ihFfEfgViKlUMbY2NKxaJzBkgHh-Phk5hqKTzK-NEEs/edit?usp=sharing) starting 4:00pm PT.
+
+One of the major output of the team effort is the [cloud native policy whitepaper](https://docs.google.com/document/d/1StDYW1zHVSF1Qswk0ScsyKw766AbAHOikyCNtqCsMMY/edit?usp=sharing)
+
+The current top priority development work is the [policy formal verification](./overview-policy-formal-verification.md) lead by @rficcaglia
+
+The team could be reached via either k8s slack channel #wg-policy or cncf slack channel #sig-security.
+
+## Governance
+
+There are now two active co-leads for Policy Team @hannibalhuang and @ericavonb. The Policy Team is under the overall governance of the CNCF Security SIG and should not be viewed as a seperate entity. All policy related contributions are welcomed to be made to the sig-security repo if needed.


### PR DESCRIPTION
As a long overdue task for me, hereby creating the introduction material for the policy team within cncf sig-security