### PR TITLE
Typo and clarify declaration of conflict

### DIFF
--- a/.github/ISSUE_TEMPLATE/security-assessment.md
+++ b/.github/ISSUE_TEMPLATE/security-assessment.md
@@ -23,7 +23,7 @@ Security Provider: yes/no (e.g. Is the primary function of the project to suppor
    - [ ] Project security lead
    - [ ] Lead Security Reviewer
    - [ ] 1 or more additional reviewer(s)
-   - [ ] Every reviewer has read [security reviewer guidelines](https://github.com/cncf/sig-security/blob/master/assessments/guide/security-reviewer.md) and stated declaration of conflicts (by each reviewer)
+   - [ ] Every reviewer has read [security reviewer guidelines](https://github.com/cncf/sig-security/blob/master/assessments/guide/security-reviewer.md) and stated declaration of conflict
    - [ ] Sign off by 2 chairs on reviewer conflicts
 - [ ] Create slack channel (e.g. #sec-assess-projectname)
 - [ ] Project lead provides draft document - see [outline](https://github.com/cncf/sig-security/blob/master/assessments/guide/outline.md)

--- a/.github/ISSUE_TEMPLATE/security-assessment.md
+++ b/.github/ISSUE_TEMPLATE/security-assessment.md
@@ -23,7 +23,7 @@ Security Provider: yes/no (e.g. Is the primary function of the project to suppor
    - [ ] Project security lead
    - [ ] Lead Security Reviewer
    - [ ] 1 or more additional reviewer(s)
-   - [ ] Declaration of reading of [security reviewer guidelines](https://github.com/cncf/sig-security/blob/master/assessments/guide/security-reviewer.md) and declaration of conflits (by each reviewer)
+   - [ ] Every reviewer has read [security reviewer guidelines](https://github.com/cncf/sig-security/blob/master/assessments/guide/security-reviewer.md) and stated declaration of conflicts (by each reviewer)
    - [ ] Sign off by 2 chairs on reviewer conflicts
 - [ ] Create slack channel (e.g. #sec-assess-projectname)
 - [ ] Project lead provides draft document - see [outline](https://github.com/cncf/sig-security/blob/master/assessments/guide/outline.md)


### PR DESCRIPTION
/s/conflics/conflicts

Declaration of conflicts seem too often an omitted step that delays the start of assessments. Rephrasing with the hope reviewers pay attention at time of volunteering and that this step doesn't get skipped.