### PR TITLE
Minor edits for the supply chain compromise catalogue

### DIFF
--- a/supply-chain-security/README.md
+++ b/supply-chain-security/README.md
@@ -16,8 +16,8 @@ risk.
 # On mitigating vulnerabilities
 
 There is on-going work to establish best practices in this area. The list of
-[Types of Supply Chain Compromises](./comrpomises/compromise-definitions.md)
-in the [Catalog of Supply Chain Compromises](./compromises) suggests some
+[types of supply chain compromises](./compromises/compromise-definitions.md)
+in the [catalog of supply chain compromises](./compromises) suggests some
 mitigation techniques for the more well understood categories.
 
 

--- a/supply-chain-security/README.md
+++ b/supply-chain-security/README.md
@@ -15,6 +15,9 @@ risk.
 
 # On mitigating vulnerabilities
 
-There is on-going work to establish best practices in this area.  
+There is on-going work to establish best practices in this area. The list of
+[Types of Supply Chain Compromises](./comrpomises/compromise-definitions.md)
+in the [Catalog of Supply Chain Compromises](./compromises) suggests some
+mitigation techniques for the more well understood categories.
 
 

--- a/supply-chain-security/compromises/compromise-definitions.md
+++ b/supply-chain-security/compromises/compromise-definitions.md
@@ -10,7 +10,8 @@ Index:
 * [Publishing Infrastructure](#publishing-infrastructure)
 * [Source Code](#source-code)
 * [Trust and Signing](#trust-and-signing)
-* [Attack Chaining](#attack-chaining)
+* [Attack Chaining](#technique-attack-chaining)
+
 
 ## Dev Tooling
 Occurs when the development machine, SDK, toolchains, or build kit have been exploited.  These exploits often result in the introduction of a backdoor by an attacker to own the development environment.
@@ -26,6 +27,7 @@ Occurs due to a lack of adherence to best practices. TypoSquatting attacks are a
 
 _Reference(s)_:
 - [Slashdot Article Regarding PyPI Attacks](https://developers.slashdot.org/story/17/09/16/2030229/pythons-official-repository-included-10-malicious-typo-squatting-modules)
+
 
 ## Publishing Infrastructure
 Occurs when the integrity or availability of shipment, publishing, or distribution mechanisms and infrastructure are affected.  This can result from a number of attacks that permit access to the infrastructure.
@@ -52,5 +54,6 @@ _Reference(s)_:
 - [Mitre: Supply Chain Compromise](https://attack.mitre.org/techniques/T1195/)
 - [Wikipedia Code Signing](https://en.wikipedia.org/wiki/Code_signing)
 
-## Attack Chaining
-Many supply chain attacks are a perfect storm of events that allow attacks to occur. They encompass multiple exploits across several areas, which are chained together to enable the final attack. The attack chain may include, or conclude with, other supply chain attacks defined here, but often start with social engineering or a lack of adherence to best practices around securing publically accessible infrastructure components.
+
+## Technique: Attack Chaining
+Sometimes a breach may be attributed to multiple lapses, with several compromises chained together to enable the attack. The attack chain may include types of supply chain attacks as defined here. However, catalogued attack chains often include other types of compromise, such as social engineering or a lack of adherence to best practices for securing publicly accessible infrastructure components.

--- a/supply-chain-security/compromises/compromise-definitions.md
+++ b/supply-chain-security/compromises/compromise-definitions.md
@@ -22,7 +22,7 @@ _Reference(s)_:
 
 
 ##  Negligence
-Associated with TypoSquatting attacks. Occurs due to a lack of adherence to best practices, when a developer failed to verify the requested dependency name was correct (spelling, name components, glyphs in use, etc).
+Occurs due to a lack of adherence to best practices. TypoSquatting attacks are a common type of attack associated with negligence, such as when a developer fails to verify the requested dependency name was correct (spelling, name components, glyphs in use, etc).
 
 _Reference(s)_:
 - [Slashdot Article Regarding PyPI Attacks](https://developers.slashdot.org/story/17/09/16/2030229/pythons-official-repository-included-10-malicious-typo-squatting-modules)

--- a/supply-chain-security/compromises/compromise-definitions.md
+++ b/supply-chain-security/compromises/compromise-definitions.md
@@ -19,7 +19,7 @@ _Reference(s)_:
 
 
 ##  Negligence
-Associated with TypoSquatting attacks, the developer failed to verify the requested package or source code was spelled correctly.  
+Associated with TypoSquatting attacks. Occurs due to a lack of adherence to best practices, when a developer failed to verify the requested dependency name was correct (spelling, name components, glyphs in use, etc).
 
 _Reference(s)_:
 - [Slashdot Article Regarding PyPI Attacks](https://developers.slashdot.org/story/17/09/16/2030229/pythons-official-repository-included-10-malicious-typo-squatting-modules)

--- a/supply-chain-security/compromises/compromise-definitions.md
+++ b/supply-chain-security/compromises/compromise-definitions.md
@@ -10,6 +10,7 @@ Index:
 * [Publishing Infrastructure](#publishing-infrastructure)
 * [Source Code](#source-code)
 * [Trust and Signing](#trust-and-signing)
+* [Attack Chaining](#attack-chaining)
 
 ## Dev Tooling
 Occurs when the development machine, SDK, toolchains, or build kit have been exploited.  These exploits often result in the introduction of a backdoor by an attacker to own the development environment.
@@ -51,4 +52,5 @@ _Reference(s)_:
 - [Mitre: Supply Chain Compromise](https://attack.mitre.org/techniques/T1195/)
 - [Wikipedia Code Signing](https://en.wikipedia.org/wiki/Code_signing)
 
-
+## Attack Chaining
+Many supply chain attacks are a perfect storm of events that allow attacks to occur. They encompass multiple exploits across several areas, which are chained together to enable the final attack. The attack chain may include, or conclude with, other supply chain attacks defined here, but often start with social engineering or a lack of adherence to best practices around securing publically accessible infrastructure components.

--- a/supply-chain-security/compromises/compromise-definitions.md
+++ b/supply-chain-security/compromises/compromise-definitions.md
@@ -15,7 +15,7 @@ Index:
 ## Dev Tooling
 Occurs when the development machine, SDK, toolchains, or build kit have been exploited.  These exploits often result in the introduction of a backdoor by an attacker to own the development environment.
 
-- _Mitigation_ - use of trusted binary repositories; verification of provenance (i.e. signatures) and/or integrity (i.e. checksums) of dev tooling downloads; bootstrapping dev toolchain from a minimal, trusted and auditable seed (ideally source code).
+- _Mitigation_ - Use of trusted binary repositories. Verification of provenance (i.e. signatures) and/or integrity (i.e. checksums) of developer tooling downloads. Bootstrapping development toolchain from a minimal, trusted and auditable seed (ideally source code).
 
 _Reference(s)_:
 - [Mitre: Supply Chain Compromise](https://attack.mitre.org/techniques/T1195/)

--- a/supply-chain-security/compromises/compromise-definitions.md
+++ b/supply-chain-security/compromises/compromise-definitions.md
@@ -14,6 +14,8 @@ Index:
 ## Dev Tooling
 Occurs when the development machine, SDK, toolchains, or build kit have been exploited.  These exploits often result in the introduction of a backdoor by an attacker to own the development environment.
 
+- _Mitigation_ - use of trusted binary repositories; verification of provenance (i.e. signatures) and/or integrity (i.e. checksums) of dev tooling downloads; bootstrapping dev toolchain from a minimal, trusted and auditable seed (ideally source code).
+
 _Reference(s)_:
 - [Mitre: Supply Chain Compromise](https://attack.mitre.org/techniques/T1195/)
 

--- a/supply-chain-security/compromises/compromise-definitions.md
+++ b/supply-chain-security/compromises/compromise-definitions.md
@@ -22,10 +22,11 @@ _Reference(s)_:
 Associated with TypoSquatting attacks, the developer failed to verify the requested package or source code was spelled correctly.  
 
 _Reference(s)_:
-- [Slashdot Article regarding PyPI attackes](https://developers.slashdot.org/story/17/09/16/2030229/pythons-official-repository-included-10-malicious-typo-squatting-modules)
+- [Slashdot Article Regarding PyPI Attacks](https://developers.slashdot.org/story/17/09/16/2030229/pythons-official-repository-included-10-malicious-typo-squatting-modules)
 
 ## Publishing Infrastructure
 Occurs when the integrity or availability of shipment, publishing, or distribution mechanisms and infrastructure are affected.  This can result from a number of attacks that permit access to the infrastructure.
+
 - _Mitigation_ - This kind of compromise can be deterred or defeated by implementing code-signing.  Code-signing requires attackers to perform multiple operations to be successful, making the level of effort higher.
 
 _Reference(s)_:


### PR DESCRIPTION
Most notably this expands the definition of negligence and adds a definition of attack chaining, both suggested in #407. I've also added some notes on mitigating dev tooling attacks.