### PR TITLE
docs: add new SIG member

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Membership governance can be viewed [here](https://github.com/cncf/sig-security/
 * Gadi Naor ([@gadinaor](https://github.com/gadinaor)), Alcide
 * Ron Vider ([@RonVider](https://github.com/RonVider)), Neo Security
 * Marco Lancini ([@marco-lancini](https://github.com/marco-lancini)), Thought Machine
+* Lewis Denham-Parry ([@denhamparry](https://github.com/denhamparry)), ControlPlane
 
 </details>
 


### PR DESCRIPTION
- adding Lewis Denham-Parry as a SIG member