### PR TITLE
Update links to usecases where currently broken

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,7 @@ PRs may be merged after at least one review as occurred, dependent on the type o
 Consistency creates clarity in communication. 
 
 * Common terms
-  * When referring to users and use cases, ensure consistency with [use cases](usecases.md)
+  * When referring to users and use cases, ensure consistency with [use cases](usecase-personas/)
   * See [CNCF Style Guide](https://github.com/cncf/foundation/blob/master/style-guide.md) for common terms. Note that the following terms are not hyphenated and all lower case, except for capitalizing the first letter when at the beginning of a
 sentence:
     * open source

--- a/NEWMEMBERS.md
+++ b/NEWMEMBERS.md
@@ -8,7 +8,7 @@ New members are advised to:
 * Initially go through the following documents in the repository:
 	* [README.md](https://github.com/cncf/sig-security/blob/master/README.md) 
 	* [CODE-OF-CONDUCT.md](https://github.com/cncf/sig-security/blob/master/CODE-OF-CONDUCT.md)
-	* [usecases.md](https://github.com/cncf/sig-security/blob/master/usecases.md)
+	* [Usecases](https://github.com/cncf/sig-security/usecase-personas/)
 * Regularly join the [Zoom meeting](https://github.com/cncf/sig-security/blob/master/README.md#meeting-time) at least for the first couple of months to get yourself up to speed. 
 * Here are multiple ways to get involved:
 	* Join the meeting as advised above and express your area of interests or if you want to work on any specific issue.

--- a/assessments/guide/outline.md
+++ b/assessments/guide/outline.md
@@ -41,7 +41,7 @@ financial cost or overwhelming the servers)
 
 ## Intended Use
 
-* Target Users and Use Cases. Provide a mapping from [standard personas](../../usecases.md)
+* Target Users and Use Cases. Provide a mapping from [standard personas](https://github.com/cncf/sig-security/usecase-personas/)
 to the nomenclature used in your project docs (which you should then use
 consistently for the remainder of this document).  Describe the scenarios in
 which the project is expected to be used. This must be specific enough to

--- a/roadmap.md
+++ b/roadmap.md
@@ -16,7 +16,7 @@ Note:  SIG-Security was rebranded from SAFE working group. The below roadmap inc
    * Explore the problem space of the working group
    * Investigating what is happening in the community today with respect to security for cloud native applications and infrastructure
    * [Presentations](issues?utf8=%E2%9C%93&q=is%3Aclosed+is%3Aissue+label%3Ausecase-presentation+) from members & guests
-   * Describe [personas & use cases](safe_usecases.md)
+   * Describe [personas & use cases](usecase-personas/)
    * Draft a picture or set of categories that will serve as a starting point for an evaluation framework
    * Solicit real world use cases and practices (and compensating controls) for projects
 3. **Describe** the landscape

--- a/security-whitepaper/cloud-native-security-whitepaper.md
+++ b/security-whitepaper/cloud-native-security-whitepaper.md
@@ -702,7 +702,7 @@ Many financial, health, government, and other entities need to comply with a spe
 
 ### Personas and Use Cases
 
-The focus is on security, protection, detection, and auto-response where ever possible. It is not necessarily development tooling alone, but security tooling that integrates transparently into the development process to enforce security policies where fast feedback and most immediate actions to remediate can occur. For specific information on cloud native security use cases refer to the [SIG-Security's use cases listing](https://github.com/cncf/sig-security/blob/master/usecases.md).
+The focus is on security, protection, detection, and auto-response where ever possible. It is not necessarily development tooling alone, but security tooling that integrates transparently into the development process to enforce security policies where fast feedback and most immediate actions to remediate can occur. For specific information on cloud native security use cases refer to the [SIG-Security's use cases listing](https://github.com/cncf/sig-security/usecase-personas/).
 
 ## Industries
 

--- a/security-whitepaper/cloud-native-security-whitepaper.md
+++ b/security-whitepaper/cloud-native-security-whitepaper.md
@@ -702,7 +702,11 @@ Many financial, health, government, and other entities need to comply with a spe
 
 ### Personas and Use Cases
 
-The focus is on security, protection, detection, and auto-response where ever possible. It is not necessarily development tooling alone, but security tooling that integrates transparently into the development process to enforce security policies where fast feedback and most immediate actions to remediate can occur. For specific information on cloud native security use cases refer to the [SIG-Security's use cases listing](https://github.com/cncf/sig-security/usecase-personas/).
+The focus is on security, protection, detection, and auto-response where ever possible. 
+It is not necessarily development tooling alone, but security tooling that integrates 
+transparently into the development process to enforce security policies where fast 
+feedback and most immediate actions to remediate can occur. For specific information
+ on cloud native security use cases refer to the [SIG-Security's use cases listing](https://github.com/cncf/sig-security/usecase-personas/).
 
 ## Industries
 


### PR DESCRIPTION
Links to usecases are currently dead after the merge of #527 

This PR updates links to the new usecase-personas folder. I have chosen to not link directly to the README.md file to align with an idea that multiple usecases could exist in this folder over time.