### PR TITLE
Attempting correction to CODEOWNERS for new TLs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -16,7 +16,7 @@
 *       @ultrasaurus @dshaw @pragashj @lumjjb @TheFoxAtWork @JustinCappos @achetal01 @ashutosh-narkar @anvega
 
 # README.md Owners
-/README.md @ultrasaurus @dshaw @pragashj @lumjjb @TheFoxAtWork @JustinCappos
+/README.md @ultrasaurus @dshaw @pragashj @lumjjb @TheFoxAtWork @JustinCappos @achetal01 @ashutosh-narkar @anvega
 
 # Security assessments
 /assessments/ @JustinCappos @ultrasaurus @pragashj @TheFoxAtWork


### PR DESCRIPTION
Looks like @ultrasaurus 's change on https://github.com/cncf/sig-security/pull/541/files  altered the permissions
https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners cites:
> Unless a later match takes precedence,

For which the previous /README.md had more restrictions and removes their merge access among others